### PR TITLE
ci: keep stable workflow file path

### DIFF
--- a/.github/workflows/Build_VIPM_Library.yml
+++ b/.github/workflows/Build_VIPM_Library.yml
@@ -1,4 +1,6 @@
 # Merged LabVIEW CI workflow
+# Keep the legacy workflow file path stable so GitHub Actions reuses the same workflow object
+# instead of creating a second workflow entry after a file rename.
 # Combines Build_VIPM_Library.yml and Check_Broken_VIs.yml into one pipeline:
 #   Check_Broken_VIs -> Build_VIPM_Library
 # All steps run sequentially on the SAME (self-hosted) machine with a SINGLE checkout.


### PR DESCRIPTION
## 背景
GitHub Actions 会把 workflow 文件路径当成 workflow 对象标识的一部分。把 `.github/workflows/Build_VIPM_Library.yml` 直接改名为 `.github/workflows/labview-ci.yml` 后，仓库里会同时存在旧对象和新对象，导致 self-hosted runner 看板继续显示旧 workflow 的历史 run。

## 本次修改
- 将合并后的 LabVIEW CI workflow 文件路径改回稳定的旧路径 `.github/workflows/Build_VIPM_Library.yml`
- 保留 `name: LabVIEW CI`，继续使用新的展示名称
- 在文件头部补充注释，说明不要再通过改路径来重命名 workflow

## 预期效果
- 后续如果继续迭代这个 workflow，只会复用同一个 GitHub Actions workflow 对象
- 避免再次因为文件改名而生成第二个 workflow 条目

## 限制
- 这个 PR **不能删除 GitHub 已经存在的旧 run 历史**，也不能让现有 runner 看板立刻清空旧记录
- 若要处理已存在的旧 workflow 对象，需要在仓库设置/API 层面额外操作；仓库内 YAML 改动无法回溯修改历史 run 元数据